### PR TITLE
shs-4864: alters source btn text for ck5

### DIFF
--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -89,6 +89,7 @@ module:
   honeypot: 0
   hook_event_dispatcher: 0
   hs_actions: 0
+  hs_admin: 0
   hs_basic_page: 0
   hs_basic_page_display: 0
   hs_blocks: 0

--- a/docroot/modules/humsci/hs_admin/assets/js/hs_admin.js
+++ b/docroot/modules/humsci/hs_admin/assets/js/hs_admin.js
@@ -1,0 +1,45 @@
+Drupal.behaviors.hsAdmin= {
+  attach: function (context) {
+    function alterSourceBtnTxt() {
+      const htmlBtn = context.querySelector('.ck-source-editing-button');
+
+      if (htmlBtn) {
+        const htmlBtnLabel = htmlBtn.querySelector('.ck-button__label');
+        htmlBtnLabel.innerText = 'HTML';
+      }
+    }
+
+    // We wait for initial load due to async racing condition of CK5.
+    window.addEventListener('load', function() {
+      alterSourceBtnTxt();
+    });
+    
+    // Then we observe when additional text areas are added on the DOM
+    const ckContainer = document.querySelector('.form-textarea-wrapper');
+    const observer = new MutationObserver(mutationCallback);
+    
+    if (ckContainer) {
+      observer.observe(ckContainer, { childList: true, subtree: true });
+    }
+
+    function mutationCallback(mutations, observer) {
+      alterSourceBtnTxt();
+      observer.disconnect();
+    }
+    
+    // Here we handle observing text format changes (Basic HTML -> Full HTML, etc.)
+    const sourceInput = context.querySelector('.js-filter-list');
+    
+    if (sourceInput) {
+      sourceInput.addEventListener('change', () => {
+        const textArea = ckContainer.querySelector('.js-text-full');
+        const observer = new MutationObserver(mutationCallback);
+        observer.observe(textArea, { attributes: true });
+  
+        function mutationCallback(mutations, observer) {
+          alterSourceBtnTxt();
+        }
+      });
+    }
+  }
+};

--- a/docroot/modules/humsci/hs_admin/hs_admin.info.yml
+++ b/docroot/modules/humsci/hs_admin/hs_admin.info.yml
@@ -1,4 +1,4 @@
-name: "HUMSCI Administration"
+name: "H&S Administration"
 type: module
 description: "A module that modifies adminstration pages for improved UX"
 core_version_requirement: "^9 || ^10"

--- a/docroot/modules/humsci/hs_admin/hs_admin.info.yml
+++ b/docroot/modules/humsci/hs_admin/hs_admin.info.yml
@@ -1,0 +1,6 @@
+name: "HUMSCI Administration"
+type: module
+description: "A module that modifies adminstration pages for improved UX"
+core_version_requirement: "^9 || ^10"
+version: "1.0"
+package: 'Humanities & Sciences'

--- a/docroot/modules/humsci/hs_admin/hs_admin.libraries.yml
+++ b/docroot/modules/humsci/hs_admin/hs_admin.libraries.yml
@@ -1,0 +1,4 @@
+hs_admin:
+  version: VERSION
+  js:
+    assets/js/hs_admin.js: {}

--- a/docroot/modules/humsci/hs_admin/hs_admin.module
+++ b/docroot/modules/humsci/hs_admin/hs_admin.module
@@ -5,13 +5,9 @@
  * Contains hs_admin.module.
  */
 
-use Drupal\Core\Form\FormStateInterface;
-
 /**
  * Implements hook_form_alter().
  */
-function hs_admin_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  if($form_id == 'node_hs_basic_page_form') {
-    $form['#attached']['library'][] = 'hs_admin/hs_admin';
-  }
+function hs_admin_preprocess_node_edit_form(&$variables) {
+  $variables['#attached']['library'][] = 'hs_admin/hs_admin';
 }

--- a/docroot/modules/humsci/hs_admin/hs_admin.module
+++ b/docroot/modules/humsci/hs_admin/hs_admin.module
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Contains hs_admin.module.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_form_alter().
+ */
+function hs_admin_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if($form_id == 'node_hs_basic_page_form') {
+    $form['#attached']['library'][] = 'hs_admin/hs_admin';
+  }
+}


### PR DESCRIPTION
## Summary
This changes the text content for the CK5 'Source' button from 'Source' to 'HTML'

## Steps to Test
1. Create a new flexible page. 
2. See that the 'Source' button for CKEditor5 has been changed from 'Source' to 'HTML' (see screenshot below)
3. Add a new component with a text area like the 'Text Area' component. Observe that it still changes the text correctly.
4. Change the input from 'Basic HTML' to 'Full HTML'. Observe that it still changes the text correctly.
5. Remove, add, play around with components to make sure it still works.

## Screenshots
![Screenshot 2023-04-17 at 2 39 12 PM](https://user-images.githubusercontent.com/8405274/232580701-bd81e27b-e736-4357-b5e4-54b3edeef4e6.png)

## Notes
- LMK if this branch is pointing to the right base.
