### PR TITLE
shs-4870: show row weights based on user role

### DIFF
--- a/docroot/modules/humsci/hs_admin/assets/css/hs_admin.css
+++ b/docroot/modules/humsci/hs_admin/assets/css/hs_admin.css
@@ -1,0 +1,10 @@
+/* Hides Show row weights button on node edits
+ * from non-developer roles.
+*/
+.tabledrag-toggle-weight-wrapper .tabledrag-toggle-weight {
+  display: none;
+}
+
+.role-administrator .tabledrag-toggle-weight-wrapper .tabledrag-toggle-weight {
+  display: inline;
+}

--- a/docroot/modules/humsci/hs_admin/assets/css/hs_admin.css
+++ b/docroot/modules/humsci/hs_admin/assets/css/hs_admin.css
@@ -5,6 +5,8 @@
   display: none;
 }
 
-.role-administrator .tabledrag-toggle-weight-wrapper .tabledrag-toggle-weight {
+.role-administrator .tabledrag-toggle-weight-wrapper .tabledrag-toggle-weight,
+/* Gin theme selector targeting */
+.tabledrag-toggle-weight-wrapper .tabledrag-toggle-weight.action-link--icon-show {
   display: inline;
 }

--- a/docroot/modules/humsci/hs_admin/assets/js/hs_admin.js
+++ b/docroot/modules/humsci/hs_admin/assets/js/hs_admin.js
@@ -41,5 +41,12 @@ Drupal.behaviors.hsAdmin= {
         }
       });
     }
+
+    // Handle Seven theme row weights
+    const rowWeightsBtn = context.querySelector('.tabledrag-toggle-weight-wrapper .tabledrag-toggle-weight');
+
+    if (rowWeightsBtn.innerText == 'Hide row weights') {
+      rowWeightsBtn.setAttribute('style', 'display: inline;');
+    }
   }
 };

--- a/docroot/modules/humsci/hs_admin/hs_admin.libraries.yml
+++ b/docroot/modules/humsci/hs_admin/hs_admin.libraries.yml
@@ -1,4 +1,7 @@
 hs_admin:
   version: VERSION
+  css:
+    base:
+      assets/css/hs_admin.css: {}
   js:
     assets/js/hs_admin.js: {}

--- a/docroot/modules/humsci/hs_admin/hs_admin.module
+++ b/docroot/modules/humsci/hs_admin/hs_admin.module
@@ -8,6 +8,23 @@
 /**
  * Implements hook_form_alter().
  */
-function hs_admin_preprocess_node_edit_form(&$variables) {
-  $variables['#attached']['library'][] = 'hs_admin/hs_admin';
+function hs_admin_page_attachments(&$variables) {
+  $logged_in = \Drupal::currentUser()->isAuthenticated();
+
+  if ($logged_in) {
+    $variables['#attached']['library'][] = 'hs_admin/hs_admin';
+  }
+}
+
+/**
+ * Implements hook_preprocess_html().
+ */
+ function hs_admin_preprocess_html(&$variables) {
+  // Get currently active user and his roles.
+  $account = \Drupal::currentUser();
+  $roles = $account->getRoles();
+
+  foreach ($roles as $role) {
+    $variables['attributes']['class'][] = 'role-' . $role;
+  }
 }


### PR DESCRIPTION
## Summary
This hides or displays the 'Display row weights' button depending on the user's role.

## Steps to Test
1. For the pages listed below in the notes, view the page both as a 'developer' role and as a non-developer role (like Site Manager for example).
2. Make sure that for the 'developer' role, the `Show row Weight` button is visible and for non-developer roles it is not visible. 

## Notes
- List of pages:
- Flexible page with components `node/12136/edit?destination=/admin/content`
- Content types with multiple values (like publications author / publication link) `node/14481/edit?destination=/admin/content%3Ftitle%3D%26type%3Dhs_publications%26status%3DAll
- Taxonomy pages `/admin/structure/taxonomy/manage/hs_person_student_type/overview`
- Sorting pages `admin/structure/entityqueue/hs_person/hs_person`

- I forked this branch off another PR branch because it already has the `hs_admin` module.

- Question
Here's the AC from the ticket. 
```
As any Developer
If I view any forms with tabledrag options -- regardless of theme
I see the "Show row weights" / "Hide row weights" toggle button as usual.

As any non-Developer site editor (Site Manager, Contributor, Author)
If the row weights are not visible (i.e., the default drag handles are visible)
Then I do not see the "Show row weights" button,
And If the row weights are visible (i.e., the drag handles are not visible)
Then I do see the "Hide row weights" button (which is the usual behavior) so that I can switch back to the drag handles.
```
For the last two points in the AC (`And If the row weights are visible...`). I did not account for this because it seems like an artifact that was ignored for the rest of the ticket based on comments. Do you know? How would the row weights be visible?

## Screenshots
![Screenshot 2023-04-24 at 3 55 18 PM](https://user-images.githubusercontent.com/8405274/234102614-174de525-26b9-4eef-8629-74a010489bcc.png)
