### PR TITLE
shs-4898: add user guide link in content type sidebars

### DIFF
--- a/config/default/core.entity_form_display.node.hs_basic_page.default.yml
+++ b/config/default/core.entity_form_display.node.hs_basic_page.default.yml
@@ -8,8 +8,26 @@ dependencies:
     - field.field.node.hs_basic_page.layout_builder__layout
     - node.type.hs_basic_page
   module:
+    - field_group
     - paragraphs
     - path
+third_party_settings:
+  field_group:
+    group_details_sidebar:
+      children: {  }
+      label: 'User Guide'
+      region: content
+      parent_name: ''
+      weight: 10
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: true
+        description: '<a href="https://hswebuserguide.stanford.edu/" title="H&S Drupal User Guide" target="_blank">H&S Drupal User Guide</a>'
+        required_fields: false
+        weight: 100
 _core:
   default_config_hash: F_j_b6OUzvMt5ycMr7eJPVLjwfl4Cvo-sos3ibg4YZI
 id: node.hs_basic_page.default

--- a/config/default/core.entity_form_display.node.hs_course.default.yml
+++ b/config/default/core.entity_form_display.node.hs_course.default.yml
@@ -75,6 +75,21 @@ third_party_settings:
         id: ''
         description: ''
         required_fields: true
+    group_user_guide:
+      children: {  }
+      label: 'User Guide'
+      region: content
+      parent_name: ''
+      weight: 24
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: true
+        description: '<a href="https://hswebuserguide.stanford.edu/" title="H&S Drupal User Guide" target="_blank">H&S Drupal User Guide</a>'
+        required_fields: false
+        weight: 100
 id: node.hs_course.default
 targetEntityType: node
 bundle: hs_course
@@ -220,6 +235,8 @@ content:
       allow_duplicate: false
       collapsible: false
       collapsed: false
+      revision: false
+      removed_reference: optional
     third_party_settings: {  }
   field_hs_course_section_location:
     type: string_textfield

--- a/config/default/core.entity_form_display.node.hs_event.default.yml
+++ b/config/default/core.entity_form_display.node.hs_event.default.yml
@@ -142,6 +142,21 @@ third_party_settings:
         formatter: closed
         description: ''
         required_fields: true
+    group_user_guide:
+      children: {  }
+      label: 'User Guide'
+      region: hidden
+      parent_name: ''
+      weight: 20
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: true
+        description: '<a href="https://hswebuserguide.stanford.edu/" title="H&S Drupal User Guide" target="_blank">H&S Drupal User Guide</a>'
+        required_fields: false
+        weight: 100
 _core:
   default_config_hash: e1Kpgyy7ewspR0Ahrghe--ElWw9lvDkBcUdMMNsWDyg
 id: node.hs_event.default

--- a/config/default/core.entity_form_display.node.hs_event_series.default.yml
+++ b/config/default/core.entity_form_display.node.hs_event_series.default.yml
@@ -7,9 +7,27 @@ dependencies:
     - field.field.node.hs_event_series.field_hs_event_series_image
     - node.type.hs_event_series
   module:
+    - field_group
     - media_library
     - path
     - text
+third_party_settings:
+  field_group:
+    group_user_guide:
+      children: {  }
+      label: 'User Guide'
+      region: content
+      parent_name: ''
+      weight: 10
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: true
+        description: '<a href="https://hswebuserguide.stanford.edu/" title="H&S Drupal User Guide" target="_blank">H&S Drupal User Guide</a>'
+        required_fields: false
+        weight: 100
 _core:
   default_config_hash: PdZewIgecWRq_vT-9nLMxeFB6ywd2apMaD-KGETJQ5Q
 id: node.hs_event_series.default

--- a/config/default/core.entity_form_display.node.hs_news.default.yml
+++ b/config/default/core.entity_form_display.node.hs_news.default.yml
@@ -12,10 +12,28 @@ dependencies:
     - node.type.hs_news
   module:
     - datetime
+    - field_group
     - link
     - media_library
     - path
     - text
+third_party_settings:
+  field_group:
+    group_user_guide:
+      children: {  }
+      label: 'User Guide'
+      region: content
+      parent_name: ''
+      weight: 14
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: true
+        description: '<a href="https://hswebuserguide.stanford.edu/" title="H&S Drupal User Guide" target="_blank">H&S Drupal User Guide</a>'
+        required_fields: false
+        weight: 100
 id: node.hs_news.default
 targetEntityType: node
 bundle: hs_news

--- a/config/default/core.entity_form_display.node.hs_person.default.yml
+++ b/config/default/core.entity_form_display.node.hs_person.default.yml
@@ -173,6 +173,21 @@ third_party_settings:
         formatter: closed
         description: ''
         required_fields: true
+    group_user_guide:
+      children: {  }
+      label: 'User Guide'
+      region: hidden
+      parent_name: ''
+      weight: 20
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: true
+        description: '<a href="https://hswebuserguide.stanford.edu/" title="H&S Drupal User Guide" target="_blank">H&S Drupal User Guide</a>'
+        required_fields: false
+        weight: 100
 _core:
   default_config_hash: dpshfsRDxezc_b830x-u9S3dyXfQyxP1yYthzWZlOJo
 id: node.hs_person.default

--- a/config/default/core.entity_form_display.node.hs_private_page.default.yml
+++ b/config/default/core.entity_form_display.node.hs_private_page.default.yml
@@ -7,10 +7,27 @@ dependencies:
     - field.field.node.hs_private_page.field_priv_wysiwyg_files
     - node.type.hs_private_page
   module:
+    - field_group
     - file
-    - insert
     - paragraphs
     - path
+third_party_settings:
+  field_group:
+    group_user_guide:
+      children: {  }
+      label: 'User Guide'
+      region: hidden
+      parent_name: ''
+      weight: 20
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: true
+        description: '<a href="https://hswebuserguide.stanford.edu/" title="H&S Drupal User Guide" target="_blank">H&S Drupal User Guide</a>'
+        required_fields: false
+        weight: 100
 id: node.hs_private_page.default
 targetEntityType: node
 bundle: hs_private_page
@@ -47,15 +64,7 @@ content:
     region: content
     settings:
       progress_indicator: throbber
-    third_party_settings:
-      insert:
-        styles:
-          link: link
-          insert__auto: 0
-          icon_link: 0
-          audio: 0
-          video: 0
-        default: link
+    third_party_settings: {  }
   path:
     type: path
     weight: 5

--- a/config/default/core.entity_form_display.node.hs_publications.default.yml
+++ b/config/default/core.entity_form_display.node.hs_publications.default.yml
@@ -14,12 +14,30 @@ dependencies:
     - field.field.node.hs_publications.field_hs_publication_year
     - node.type.hs_publications
   module:
+    - field_group
     - hs_field_helpers
     - inline_entity_form
     - link
     - media_library
     - path
     - text
+third_party_settings:
+  field_group:
+    group_user_guide:
+      children: {  }
+      label: 'User Guide'
+      region: content
+      parent_name: ''
+      weight: 17
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: true
+        description: '<a href="https://hswebuserguide.stanford.edu/" title="H&S Drupal User Guide" target="_blank">H&S Drupal User Guide</a>'
+        required_fields: false
+        weight: 100
 _core:
   default_config_hash: YhHMDht0zK7u6dzUkYGt05lJdgV84TQV7AKbR4AdXss
 id: node.hs_publications.default
@@ -59,9 +77,10 @@ content:
       collapsible: false
       collapsed: false
       revision: false
+      removed_reference: optional
     third_party_settings: {  }
   field_hs_publication_citation:
-    type: string_textarea
+    type: text_textarea
     weight: 1
     region: content
     settings:

--- a/config/default/core.entity_form_display.node.hs_research.default.yml
+++ b/config/default/core.entity_form_display.node.hs_research.default.yml
@@ -6,8 +6,26 @@ dependencies:
     - field.field.node.hs_research.body
     - node.type.hs_research
   module:
+    - field_group
     - path
     - text
+third_party_settings:
+  field_group:
+    group_user_guide:
+      children: {  }
+      label: 'User Guide'
+      region: content
+      parent_name: ''
+      weight: 9
+      format_type: details_sidebar
+      format_settings:
+        classes: ''
+        show_empty_fields: true
+        id: ''
+        open: true
+        description: '<a href="https://hswebuserguide.stanford.edu/" title="H&S Drupal User Guide" target="_blank">H&S Drupal User Guide</a>'
+        required_fields: false
+        weight: 100
 _core:
   default_config_hash: iY6Nkb_6d_hneCusG2QFm7OUboK2OD_P5v08Fkk3Fe0
 id: node.hs_research.default
@@ -17,7 +35,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 121
+    weight: 8
     region: content
     settings:
       rows: 9
@@ -27,40 +45,40 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
-    weight: 10
+    weight: 2
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 15
+    weight: 3
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 120
+    weight: 7
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 16
+    weight: 4
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -68,7 +86,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 1
     region: content
     settings:
       match_operator: CONTAINS
@@ -77,7 +95,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 50
+    weight: 6
     region: content
     settings: {  }
     third_party_settings: {  }


### PR DESCRIPTION
## Summary
This adds a link to the user guide in the sidebar of every content type.

## Steps to Test
1. Click 'Add Content' for every content type. In the sidebar, there should be a new item 'User Guide' that is open by default.
2. Click the link to make sure it works. It should open in a new tab.

## Screenshots
![Screenshot 2023-04-25 at 10 55 23 AM](https://user-images.githubusercontent.com/8405274/234317765-c81aea5a-eaee-478d-b95a-a805e4bec8fe.png)
