### PR TITLE
shs-4939: change callout style default label

### DIFF
--- a/config/default/field.storage.paragraph.field_hs_callout_style.yml
+++ b/config/default/field.storage.paragraph.field_hs_callout_style.yml
@@ -13,7 +13,7 @@ settings:
   allowed_values:
     -
       value: default
-      label: Default
+      label: None
     -
       value: hs_well
       label: Well


### PR DESCRIPTION
## Summary
Changes callout background field default label

## Steps to Test
1. Add a Callout box component on a flexible page. Notice that the default label for 'Callout Style' is now 'None'

## Screenshots
![Screenshot 2023-05-22 at 1 29 31 PM](https://github.com/SU-HSDO/suhumsci/assets/8405274/1c34c306-02db-4b14-9153-fe5998938b7b)
