### PR TITLE
SHS-4873: [EX] Form display sidebar and tab improvements, esp for Flexible Pages

### DIFF
--- a/docroot/modules/humsci/hs_admin/hs_admin.module
+++ b/docroot/modules/humsci/hs_admin/hs_admin.module
@@ -5,6 +5,8 @@
  * Contains hs_admin.module.
  */
 
+use Drupal\Core\Render\Markup;
+
 /**
  * Implements hook_preprocess_node_edit_form().
  */
@@ -38,5 +40,42 @@ function hs_admin_toolbar_alter(&$items) {
   if ($user->hasPermission('hide manage link') && $uid != 1) {
      unset($items['admin_toolbar_tools']);
      unset($items['administration']);
+  }
+}
+
+/**
+ * Implements hook_preprocess_menu_local_tasks().
+ */
+function hs_admin_preprocess_menu_local_tasks(&$variables) {
+  // Disable edit/create node tabs for publish and delete.
+  unset($variables['primary']['entity.node.publish']);
+  unset($variables['primary']['entity.node.delete_form']);
+}
+
+/**
+ * Implements hook_preprocess_details().
+ */
+function hs_admin_preprocess_details(&$variables) {
+  $expanded = ['menu settings'];
+  // Close all sidebar elements if not Menu Settings.
+  $title = $variables['title'] ?? '';
+  if (!is_array($title) && in_array(strtolower((string)$title), $expanded, TRUE)) {
+    $variables['attributes']['open'] = 'open';
+  }
+  else {
+    unset($variables['attributes']['open']);
+  }
+}
+
+/**
+ * Impelments hook_preprocess_form_element().
+ */
+function hs_admin_preprocess_form_element(&$variables) {
+  $name = $variables['name'] ?? '';
+  $type = $variables['element']['#type'] ?? '';
+  // Check that it's the published status field
+  // and check it for a label.
+  if ($type === 'item' && strtolower($name) === 'meta[published]' && isset($variables['children'])) {
+    $variables['children'] = Markup::create('Revisions');
   }
 }


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Add hooks to modify side bar of node edit and create forms
- Add hooks to modify the tabs of node edit and create forms 

## Urgency
_medium_

## Steps to Test
 Ensure the following are true when creating and editing any node type:
- [ ] Side menu:
  - [ ] Menu Settings (expanded)
  - [ ] Authoring Information (collapsed)
  - [ ] Promotion Options (collapsed)
  - [ ] URL Alias (collapsed)
  - [ ] 'Publish' (collapsed)  ➝ Rename to "Revisions"
  - [ ] "Publish/Unpublish" tab removed from the top
- [ ] "Delete" tab removed from the top
- [ ]  Permissions, including publishing/unpublishing or deleting content via the options at the bottom of the form, remain the same.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
