### PR TITLE
SHS-4929: Hide Caption/Credits on Images in Views (new defaults)

### DIFF
--- a/config/default/views.view.hs_default_news.yml
+++ b/config/default/views.view.hs_default_news.yml
@@ -657,9 +657,10 @@ display:
           click_sort_column: target_id
           type: media_image_formatter
           settings:
-            view_mode: caption_credit
+            view_mode: full
             link: true
             image_style: hs_medium_rectangle_360x250
+            remove_alt: false
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -1191,9 +1192,10 @@ display:
           click_sort_column: target_id
           type: media_image_formatter
           settings:
-            view_mode: caption_credit
+            view_mode: full
             link: true
             image_style: hs_medium_rectangle_360x250
+            remove_alt: false
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -1708,9 +1710,10 @@ display:
           click_sort_column: target_id
           type: media_image_formatter
           settings:
-            view_mode: caption_credit
+            view_mode: full
             link: true
             image_style: hs_medium_rectangle_360x250
+            remove_alt: false
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -2061,9 +2064,10 @@ display:
           click_sort_column: target_id
           type: media_image_formatter
           settings:
-            view_mode: caption_credit
+            view_mode: full
             link: true
             image_style: hs_medium_rectangle_360x250
+            remove_alt: false
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -3017,9 +3021,10 @@ display:
           click_sort_column: target_id
           type: media_image_formatter
           settings:
-            view_mode: caption_credit
+            view_mode: full
             link: true
             image_style: hs_medium_rectangle_360x250
+            remove_alt: false
           group_column: target_id
           group_columns: {  }
           group_rows: true

--- a/config/default/views.view.hs_default_people.yml
+++ b/config/default/views.view.hs_default_people.yml
@@ -607,9 +607,10 @@ display:
           click_sort_column: target_id
           type: media_image_formatter
           settings:
-            view_mode: caption_credit
+            view_mode: full
             link: true
             image_style: hs_small_square_200x200
+            remove_alt: false
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -1137,9 +1138,10 @@ display:
           click_sort_column: target_id
           type: media_image_formatter
           settings:
-            view_mode: caption_credit
+            view_mode: full
             link: true
             image_style: hs_medium_square_360x360
+            remove_alt: false
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -2206,9 +2208,10 @@ display:
           click_sort_column: target_id
           type: media_image_formatter
           settings:
-            view_mode: caption_credit
+            view_mode: full
             link: true
             image_style: hs_medium_square_360x360
+            remove_alt: false
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -3344,9 +3347,10 @@ display:
           click_sort_column: target_id
           type: media_image_formatter
           settings:
-            view_mode: caption_credit
+            view_mode: full
             link: true
             image_style: hs_small_square_200x200
+            remove_alt: false
           group_column: target_id
           group_columns: {  }
           group_rows: true

--- a/config/default/views.view.hs_default_publications.yml
+++ b/config/default/views.view.hs_default_publications.yml
@@ -769,9 +769,10 @@ display:
           click_sort_column: target_id
           type: media_image_formatter
           settings:
-            view_mode: caption_credit
+            view_mode: full
             link: true
             image_style: hs_large_scaled_480px
+            remove_alt: false
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -1479,9 +1480,10 @@ display:
           click_sort_column: target_id
           type: media_image_formatter
           settings:
-            view_mode: caption_credit
+            view_mode: full
             link: true
             image_style: responsive_small
+            remove_alt: false
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -1986,9 +1988,10 @@ display:
           click_sort_column: target_id
           type: media_image_formatter
           settings:
-            view_mode: caption_credit
+            view_mode: full
             link: true
             image_style: responsive_small
+            remove_alt: false
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -2477,9 +2480,10 @@ display:
           click_sort_column: target_id
           type: media_image_formatter
           settings:
-            view_mode: caption_credit
+            view_mode: full
             link: true
             image_style: responsive_small
+            remove_alt: false
           group_column: target_id
           group_columns: {  }
           group_rows: true
@@ -3119,9 +3123,10 @@ display:
           click_sort_column: target_id
           type: media_image_formatter
           settings:
-            view_mode: caption_credit
+            view_mode: full
             link: true
             image_style: hs_large_scaled_480px
+            remove_alt: false
           group_column: target_id
           group_columns: {  }
           group_rows: true


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Update Default News, Default People and Default Publications views to change media image view mode and hide the Caption/Details element displayed over the images.

## Need Review By (Date)
_['10/30', 'asap', etc.]_

## Urgency
Normal

## Steps to Test
1. Import configuration into your test site (you can use `hs-colorful`)
2. Visit `/default-views/publications`, `/default-views/people` and `/default-views/news` and confirm that the caption text is not shown over the images in any case (use https://hs-colorful-prod.stanford.edu/ as a reference)

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
