### PR TITLE
Shs 4957 legacy caption bug

### DIFF
--- a/docroot/modules/humsci/hs_layouts/patterns/horizontal-card/css/horizontal-card--overrides.css
+++ b/docroot/modules/humsci/hs_layouts/patterns/horizontal-card/css/horizontal-card--overrides.css
@@ -1,0 +1,4 @@
+/* Manual overrides to necessary to address outdated Grunt compiling */
+.ptype-hs-postcard .horizontal-card__img .hs-postcard {
+  position: relative;
+}

--- a/docroot/modules/humsci/hs_layouts/patterns/horizontal-card/horizontal-card.ui_patterns.yml
+++ b/docroot/modules/humsci/hs_layouts/patterns/horizontal-card/horizontal-card.ui_patterns.yml
@@ -44,4 +44,5 @@ horizontal_card:
         css:
           component:
             css/horizontal-card.css: { }
+            css/horizontal-card--overrides.css: { }
   use: "@hs_layouts/horizontal-card/horizontal-card.html.twig"

--- a/docroot/profiles/humsci/su_humsci_profile/modules/humsci_default_content/humsci_default_content.info.yml
+++ b/docroot/profiles/humsci/su_humsci_profile/modules/humsci_default_content/humsci_default_content.info.yml
@@ -3,7 +3,7 @@ description: 'DO NOT INSTALL. This is for profile installation task only.'
 core_version_requirement: '^9.4 || ^10'
 hidden: true
 type: module
-version: 9.4.22
+version: 9.4.23
 default_content:
   shortcut:
     - 0c69448d-c6fa-4fb8-9b2e-f93f3a955baf

--- a/docroot/profiles/humsci/su_humsci_profile/modules/humsci_events_listeners/humsci_events_listeners.info.yml
+++ b/docroot/profiles/humsci/su_humsci_profile/modules/humsci_events_listeners/humsci_events_listeners.info.yml
@@ -14,4 +14,4 @@ dependencies:
   - 'hook_event_dispatcher:toolbar_event_dispatcher'
   - 'hook_event_dispatcher:user_event_dispatcher'
   - 'hook_event_dispatcher:views_event_dispatcher'
-version: 9.4.22
+version: 9.4.23

--- a/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml
+++ b/docroot/profiles/humsci/su_humsci_profile/su_humsci_profile.info.yml
@@ -1,7 +1,7 @@
 name: 'Stanford HumSci'
 type: profile
 description: 'Installation profile for HumSci Drupal'
-version: 9.4.22
+version: 9.4.23
 core_version_requirement: '^9.4 || ^10'
 themes:
   - material_admin


### PR DESCRIPTION
## Summary
Fixes a caption bug on legacy postcards

## Steps to Test
1. On the Archaeology site, go to `/research/faculty-projects` when logged out and make sure the caption is with the image

## Notes
- There's no release branch, so I chose `develop`
- Due to the antiquated `Gruntfile.js`, I'm adding the CSS manually. We discussed it in the internal standup today, but happy to discuss the why it's not compiled.
