### PR TITLE
fix: this fixes a small console error related to hs_admin

### DIFF
--- a/docroot/modules/humsci/hs_admin/assets/js/hs_admin.js
+++ b/docroot/modules/humsci/hs_admin/assets/js/hs_admin.js
@@ -44,7 +44,7 @@ Drupal.behaviors.hsAdmin= {
 
     // Handle Seven theme row weights
     const rowWeightsBtn = context.querySelector('.tabledrag-toggle-weight-wrapper .tabledrag-toggle-weight');
-   
+
     if (rowWeightsBtn && rowWeightsBtn.innerText == 'Hide row weights') {
       rowWeightsBtn.setAttribute('style', 'display: inline;');
     }

--- a/docroot/modules/humsci/hs_admin/assets/js/hs_admin.js
+++ b/docroot/modules/humsci/hs_admin/assets/js/hs_admin.js
@@ -44,8 +44,9 @@ Drupal.behaviors.hsAdmin= {
 
     // Handle Seven theme row weights
     const rowWeightsBtn = context.querySelector('.tabledrag-toggle-weight-wrapper .tabledrag-toggle-weight');
-
-    if (rowWeightsBtn.innerText == 'Hide row weights') {
+   
+    if (rowWeightsBtn && rowWeightsBtn.innerText == 'Hide row weights') {
+      console.log('oh hai')
       rowWeightsBtn.setAttribute('style', 'display: inline;');
     }
   }

--- a/docroot/modules/humsci/hs_admin/assets/js/hs_admin.js
+++ b/docroot/modules/humsci/hs_admin/assets/js/hs_admin.js
@@ -46,7 +46,6 @@ Drupal.behaviors.hsAdmin= {
     const rowWeightsBtn = context.querySelector('.tabledrag-toggle-weight-wrapper .tabledrag-toggle-weight');
    
     if (rowWeightsBtn && rowWeightsBtn.innerText == 'Hide row weights') {
-      console.log('oh hai')
       rowWeightsBtn.setAttribute('style', 'display: inline;');
     }
   }


### PR DESCRIPTION
## Summary
There is no ticket for this. When trying to recreate a bug in another ticket, I noticed this small console error related to the `hs_admin` module. This fixes.

## Steps to Test
1. Go to Colorful or Traditional when signed in. Visit a page and check the console. See that there are no console errors related to `innerText`

