### PR TITLE
shs-4962: adjust minimal html available buttons

### DIFF
--- a/config/default/editor.editor.minimal_html.yml
+++ b/config/default/editor.editor.minimal_html.yml
@@ -14,7 +14,6 @@ settings:
       - bold
       - italic
       - heading
-      - style
       - horizontalLine
       - sourceEditing
       - '|'
@@ -23,9 +22,6 @@ settings:
       - bulletedList
       - numberedList
       - '|'
-      - blockQuote
-      - code
-      - insertTable
   plugins:
     ckeditor5_heading:
       enabled_headings:


### PR DESCRIPTION
## Summary
Adjusts minimal html buttons

## Steps to Test
1. Create a flexible page. In the full width region, add a hero layered slider. Expand overlay details.
2. You should **not** see the following buttons now: Styles, Blockquote, Code and Table insert.

### Notes
Due to a Drupal bug every time I saved this, I had to manually edit this file, but it works fine on my end. 