### PR TITLE
feat: removes code button from basic html ck5 format

### DIFF
--- a/config/default/editor.editor.basic_html.yml
+++ b/config/default/editor.editor.basic_html.yml
@@ -34,8 +34,6 @@ settings:
       - sourceEditing
       - undo
       - redo
-      - '|'
-      - code
   plugins:
     ckeditor5_heading:
       enabled_headings:


### PR DESCRIPTION
## Summary
Removes code button from basic html format

## Steps to Test
1. Create a flexible page. Add a Text Area component. Verify the 'code' button on the right is no longer there.

### Screenshots:
![Screenshot 2023-06-28 at 3 26 55 PM](https://github.com/SU-HSDO/suhumsci/assets/8405274/f0e76f1d-949f-439d-aaae-7bb0bd866f50)
