### PR TITLE
SHS-4979: Apply patch on confirm_leave module to prevent warning on node save

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -322,6 +322,9 @@
                 "https://www.drupal.org/project/config_ignore/issues/2857247": "https://www.drupal.org/files/issues/2020-01-11/support-for-export-2857247-44.patch",
                 "https://www.drupal.org/project/config_ignore/issues/2865419": "https://www.drupal.org/files/issues/2020-07-20/config_ignore-wildcard_force_import.patch"
             },
+            "drupal/confirm_leave": {
+                "https://www.drupal.org/project/confirm_leave/issues/3119397": "https://www.drupal.org/files/issues/2020-03-12/3119397-2.patch"
+            },
             "drupal/core": {
                 "https://www.drupal.org/project/drupal/issues/2807629": "https://www.drupal.org/files/issues/2022-12-16/2807629-75.patch",
                 "https://www.drupal.org/project/drupal/issues/2999491": "https://www.drupal.org/files/issues/2020-10-06/2999491--reusable-title-display--56.patch",


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
Apply patch on confirm_leave module to prevent warning on node save

## Urgency
_normal_

## Steps to Test
1. Execute `lando composer install` to apply patch. Confirm that the patch is applied correctly
2. Login into the site and edit an existing node. Change some fields and press the form "Cancel" button. A warning should be displayed
3. Now change some fields and save the node. There should be no warning message.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
