### PR TITLE
shs-4968: removes link features in basic html

### DIFF
--- a/config/default/editor.editor.basic_html.yml
+++ b/config/default/editor.editor.basic_html.yml
@@ -133,9 +133,7 @@ settings:
       allow_view_mode_override: true
     editor_advanced_link_link:
       enabled_attributes:
-        - class
         - id
-        - target
         - title
     linkit_extension:
       linkit_enabled: true

--- a/config/default/editor.editor.basic_html_without_media.yml
+++ b/config/default/editor.editor.basic_html_without_media.yml
@@ -128,9 +128,7 @@ settings:
         - justify
     editor_advanced_link_link:
       enabled_attributes:
-        - class
         - id
-        - target
         - title
     linkit_extension:
       linkit_enabled: false


### PR DESCRIPTION
## Summary
Removes the classes and target fields in the link options of WYSIWYG editor.

## Steps to Test
1. Create a flexible page. Go to the WYSIWYG. Add some text and make it a link. Observe how the classes and target fields of the advanced link options are no longer there.


