### PR TITLE
SHS-4977: Change messages color to improve contrast

### DIFF
--- a/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
+++ b/docroot/themes/humsci/su_humsci_gin_admin/dist/su_humsci_gin_admin.css
@@ -38,3 +38,19 @@ html:not(.gin--dark-mode) .user-logged-in[data-gin-accent="custom"] {
 .linkit-result-line--title, .linkit-result-line--description {
   white-space: normal !important;
 }
+
+/* Messsages custom colors */
+.messages--status {
+  --gin-color-green-light: #fff;
+  --gin-bg-green: #008566;
+}
+
+.messages--warning {
+  --gin-color-warning-light: #000;
+  --gin-bg-warning: #e98300;
+}
+
+.messages--error {
+  --gin-color-danger-light: #fff;
+  --gin-bg-danger: #b1040e;
+}


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Change messages color to improve contrast

## Urgency
- normal

## Steps to Test
1. Confirm that the color of the status, warning and error messages changes are correctly applied (see [the ticket](https://app.clickup.com/t/36718269/SHS-4977) and screenshots for the color reference). To test this, do the following:
  - Visit `/admin/config/user-interface/shortcut/manage/default/customize`
  - Change the order of some links. A warning message should appear.
  - Save the changes. A status message should be displayed. Also confirm that the "Show row heights" link doesn't overlap the message box (this was present on the bug description, but is not happening anymore, it was probably fixed by a gin update).
  - You might see a "Simplesamlphp" error message in all pages. If not, create a new shortcut using the button on the top right and add a  non-existing URL. An error message should appear.

<img width="1581" alt="Screenshot 2023-07-16 at 19 01 11" src="https://github.com/fourkitchens/suhumsci/assets/3496574/ff5b03fa-1b80-48aa-85f4-91e59e710713">

<img width="1525" alt="Screenshot 2023-07-16 at 19 01 25" src="https://github.com/fourkitchens/suhumsci/assets/3496574/476977c5-7471-44e9-8faf-1260c7d7201d">


## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
