### PR TITLE
SHS-4940: Always show help text in forms

### DIFF
--- a/config/default/config_ignore.settings.yml
+++ b/config/default/config_ignore.settings.yml
@@ -23,6 +23,7 @@ ignored_config_entities:
   - 'field.field.node.hs_basic_page.field_hs_page_hero:settings.handler_settings'
   - 'field.field.node.hs_private_page.field_hs_priv_page_components:settings.handler_settings'
   - ~gin.settings
+  - ~su_humsci_gin_admin.settings
   - 'google_analytics.settings:account'
   - 'google_analytics.settings:cross_domains'
   - 'google_analytics.settings:domain_mode'

--- a/config/default/su_humsci_gin_admin.settings.yml
+++ b/config/default/su_humsci_gin_admin.settings.yml
@@ -1,5 +1,5 @@
 _core:
-  default_config_hash: illvUYAXY65X9WYsbByc0NJifOSPtuhmVRPY3BG3zGU
+  default_config_hash: LhA2ru22AJBfZNlPrw2m-U_mDx4jGOgniXLr6ma9e84
 favicon:
   use_default: true
 features:
@@ -21,5 +21,5 @@ high_contrast_mode: false
 accent_color: '#0550e6'
 focus_color: '#007dfa'
 layout_density: default
-show_description_toggle: true
+show_description_toggle: false
 show_user_theme_settings: false


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Update custom gin admin theme settings to always show help text

## Urgency
- Normal

## Steps to Test
1. Visit `/admin/appearance/settings/su_humsci_gin_admin` and confirm that the option "Enable form description toggle" (under "Settings") is disabled.
2. Edit a Flexible Page (for example the homepage) or add a new one and confirm that the help texts in the form are always visible.

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
