### PR TITLE
SHS-4863: Hide text format dropdown for non-developer users

### DIFF
--- a/docroot/modules/humsci/hs_admin/assets/css/hs_admin.css
+++ b/docroot/modules/humsci/hs_admin/assets/css/hs_admin.css
@@ -14,10 +14,10 @@
 }
 
 /* Hides text format container from non-developer roles. */
-.text-format-wrapper .form-wrapper.filter-wrapper {
+.text-full .form-wrapper.filter-wrapper {
   display: none;
 }
 
-.role-administrator .text-format-wrapper .form-wrapper.filter-wrapper {
+.role-administrator .text-full .form-wrapper.filter-wrapper {
   display: block;
 }


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Fix class used for hiding the text format dropdown (See #8)

## Steps to Test
1. Masquerade or login as an user with the site manager role
2. Create or edit content (content types, paragraphs) with formatted text fields. Confirm that you don't see the text format dropdown below the WYSIWYG editor nor the "About text formats" link.
3. Test again as a developer user. You should see the dropdown and the "About text formats" link

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
