### PR TITLE
SHS-4487: Change paragraph label in CKEditor heading plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -332,7 +332,8 @@
                 "https://www.drupal.org/project/drupal/issues/3306916": "https://www.drupal.org/files/issues/2022-08-30/file_validate_size.patch",
                 "drupallink conflict with anchorlink": "patches/drupallink.patch",
                 "views form null fix": "patches/core-views.patch",
-                "CKEditor 5 isn't respecting field widgets row settings": "https://www.drupal.org/files/issues/2023-02-02/3241295-d9.5-101.patch"
+                "CKEditor 5 isn't respecting field widgets row settings": "https://www.drupal.org/files/issues/2023-02-02/3241295-d9.5-101.patch",
+                "CKEditor 5 headings plugin paragraph label change": "patches/ckeditor5-paragraph-rename.patch"
             },
             "drupal/ds": {
                 "https://www.drupal.org/project/ds/issues/2939322": "https://www.drupal.org/files/issues/2020-01-07/ds-content_entity-2939322-11.patch"

--- a/patches/ckeditor5-paragraph-rename.patch
+++ b/patches/ckeditor5-paragraph-rename.patch
@@ -1,0 +1,13 @@
+diff --git a/core/modules/ckeditor5/ckeditor5.ckeditor5.yml b/core/modules/ckeditor5/ckeditor5.ckeditor5.yml
+index 0a19bdca90..e7a97168b2 100644
+--- a/core/modules/ckeditor5/ckeditor5.ckeditor5.yml
++++ b/core/modules/ckeditor5/ckeditor5.ckeditor5.yml
+@@ -39,7 +39,7 @@ ckeditor5_heading:
+         # @see https://ckeditor.com/docs/ckeditor5/latest/api/module_heading_heading-HeadingConfig.html#member-options
+         #   for details on what each of these config properties do.
+         options:
+-          - { model: 'paragraph', title: 'Paragraph', class: 'ck-heading_paragraph' }
++          - { model: 'paragraph', title: 'Normal', class: 'ck-heading_paragraph' }
+           - { model: 'heading1', view: 'h1', title: 'Heading 1', class: 'ck-heading_heading1' }
+           - { model: 'heading2', view: 'h2', title: 'Heading 2', class: 'ck-heading_heading2' }
+           - { model: 'heading3', view: 'h3', title: 'Heading 3', class: 'ck-heading_heading3' }


### PR DESCRIPTION
# READY FOR REVIEW

## Summary
- Add patch to override "Paragraph" label in CKEditor heading plugin

## Steps to Test
1. Create a flexible page
2. Confirm that the default option in the headings selector in CKEditor is "Normal" instead of "Paragraph"

## PR Checklist
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
- [Humsci Basic PR Checklist](https://github.com/SU-HSDO/suhumsci/blob/develop/docs/HumsciBasicPRChecklist.md)
